### PR TITLE
Cleanups following the static aframe template branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The site will now be available on http://localhost:3000.
 - [Room DOM](./docs/Room%20DOM.md)
 - [Server Rooms](./docs/Server%20Rooms.md)
 - [Client Room Context](./docs/Client%20Room%20Context.md)
+- [Video Synchronization](./docs/Video%20Synchronization.md)
 
 ### Tech Stack
 

--- a/docs/Client Room Context.md
+++ b/docs/Client Room Context.md
@@ -79,28 +79,3 @@ emitRoomData({
   songs: [...roomData.get().songs, newSong],
 });
 ```
-
-## TODO MAYBE MOVE SOMEWHERE
-
-### `currentTime`
-
-There are roughly three kinds of "current time" states in play for each room and there is no time in which the video is playing and _all three_ could possibly be the same. lol
-
-- DOM: The literal `<video>` element's `.currentTime` property
-- React: That is, every 500ms or so, read from and then written to the React state that stores the local copy of room data
-- Node: Stored on the server (which is continuously updated by whoever clicked play most recently)
-
-> in theory we could have each of the player and the server figure out their relative times, but that's actually super hard. aybe there are libraries for it?
-> if we get that, then we could have the server tell each client what client-relative timestamp the video starts at...
-
-whenever we the player write to React, we the player then also send a message to the server (node) to update the currentTime.
-The server then sends a socket message to everyone else, and everyone else writes the new currentTime to React, which causes a write to the DOM _if_ the video isn't playing.
-
-we never write currentTime to the video if it's playing. because that would be a jank experience.
-
-if the "player" leaves, they will no longer be sending currentTime updates to the server...
-...and if someone then joins the room, they'll get an out of date currentTime
-
-so to resolve this, we'll need to let the "player" be delegated to someone
-
-there are probably bugs around skipping to a next stong

--- a/docs/Client Room Context.md
+++ b/docs/Client Room Context.md
@@ -79,3 +79,28 @@ emitRoomData({
   songs: [...roomData.get().songs, newSong],
 });
 ```
+
+## TODO MAYBE MOVE SOMEWHERE
+
+### `currentTime`
+
+There are roughly three kinds of "current time" states in play for each room and there is no time in which the video is playing and _all three_ could possibly be the same. lol
+
+- DOM: The literal `<video>` element's `.currentTime` property
+- React: That is, every 500ms or so, read from and then written to the React state that stores the local copy of room data
+- Node: Stored on the server (which is continuously updated by whoever clicked play most recently)
+
+> in theory we could have each of the player and the server figure out their relative times, but that's actually super hard. aybe there are libraries for it?
+> if we get that, then we could have the server tell each client what client-relative timestamp the video starts at...
+
+whenever we the player write to React, we the player then also send a message to the server (node) to update the currentTime.
+The server then sends a socket message to everyone else, and everyone else writes the new currentTime to React, which causes a write to the DOM _if_ the video isn't playing.
+
+we never write currentTime to the video if it's playing. because that would be a jank experience.
+
+if the "player" leaves, they will no longer be sending currentTime updates to the server...
+...and if someone then joins the room, they'll get an out of date currentTime
+
+so to resolve this, we'll need to let the "player" be delegated to someone
+
+there are probably bugs around skipping to a next stong

--- a/docs/Video Synchronization.md
+++ b/docs/Video Synchronization.md
@@ -1,0 +1,49 @@
+# Video Synchronization
+
+> Read [Client Room Context.md](./Client%20Room%20Context.md) before this page to get an understanding of general client<>server communication.
+
+Synchronizing a video between multiple clients and a server is _very hard_.
+It's impossible to get exactly right and exceedingly difficult to get right with a margin of error in milliseconds.
+
+- Computers generally have slightly different understandings of what the "current time" is.
+- Latency over networks is unreliable but guaranteed to not be instantaneous.
+- Execution speed is not guaranteed to be the same across multiple runs of the same code.
+
+## Players vs. Non-Players
+
+We use a "good enough" approach that optimizes for the scenario of one client pressing "play" and other clients in the same room knowing to start their videos.
+This is done by designating a client as the "player" for a room if they're the one to press play on a previously paused video.
+
+Once designated the room's player, a client will continuously message a new value for the room data's `currentTime` to the server.
+Other, non-player clients will then receive that update and remember it locally.
+
+> The "player" concept is roughly similiar to A-Frame's "ownership" concept, except it's manually implemented to give us more control over timing.
+
+## Time Storage
+
+There are roughly three kinds of "current time" states in play for each room.
+
+- **DOM**: The browser's `<video>` element stores a native `.currentTime` property.
+- **React**: A piece of React state so client logic can use a reliable measure of the video's `.currentTime`.
+  updated every 500ms or so to be a reading of the DOM's `.currentTime`.
+- **Node**: Stored on the server as a member of the
+  (which is continuously updated by whoever clicked play most recently)
+
+Amusingly, there is no time in which the video is playing and _all three_ could possibly be the same, as there is variable latency between each step.
+
+Therefore, clients do not update the native DOM `<video>` `.currentTime` property when the video is _playing_; doing so would cause jittery playback.
+They instead only update it when _paused_, as a reaction to a server message.
+
+### Player Data Flow
+
+Players read their native `<video>` `.currentTime` and update both their React state and the server's based on it.
+
+1. **DOM** to **React**: Client logic on the player reads from the native DOM's `<video>` on an interval (currently 500ms, but eventually ideally much more rapid) to write a copy of it to React state.
+2. **React** to **Node**: Whenever that interval fires, it also emits an update to the server to update the server state.
+
+### Non-Player Data Flow
+
+Non-players receive data in the opposite direction:
+
+1. **Node** to **React**: When the server receives a room data update containing a new `currentTime` from a player, it messages that data out to the rest of the room.
+2. **React** to **DOM**: If the video is paused, that new `currentTime` will be applied to it.

--- a/next.config.js
+++ b/next.config.js
@@ -9,16 +9,16 @@ module.exports = {
       issuer: {
         test: /\.(js|ts)x?$/,
       },
-      test: /\.svg$/,
-      use: ["@svgr/webpack", "url-loader"],
+      test: /\.html$/,
+      use: ["html-loader"],
     });
 
     config.module.rules.push({
       issuer: {
         test: /\.(js|ts)x?$/,
       },
-      test: /\.html$/,
-      use: ["html-loader"],
+      test: /\.svg$/,
+      use: ["@svgr/webpack", "url-loader"],
     });
 
     return config;

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -15,3 +15,8 @@ export const controlIds = {
   volumeHighButton: "volume-high-button",
   volumeLowButton: "volume-low-button",
 };
+
+/**
+ * How often to emit currentTime updates.
+ */
+export const videoSyncInterval = 500;

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -17,6 +17,11 @@ export const controlIds = {
 };
 
 /**
+ * How much, out of 1, to change volume on each button press.
+ */
+export const volumeChangeRate = 0.25;
+
+/**
  * How often to emit currentTime updates.
  */
 export const videoSyncInterval = 500;

--- a/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
+++ b/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
@@ -34,7 +34,11 @@ export const DynamicSceneConnected: React.FC<DynamicSceneConnectedProps> = ({
   );
 
   const emitRoomData = useRoomDataEmit(emit, roomContextData.roomData);
-  const roomContextValue = { ...roomContextData, emitRoomData };
+  const roomContextValue = {
+    ...roomContextData,
+    emitRoomData,
+    originalRoomData: roomData,
+  };
 
   useRoomDataSyncing(roomContextValue, socket);
 

--- a/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
+++ b/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
@@ -20,6 +20,7 @@ export const DynamicSceneConnected: React.FC<DynamicSceneConnectedProps> = ({
   settings,
   socket,
 }) => {
+  // ima document this lol
   const emit = useCallback<EmitUpdate>(
     (event, data) => {
       socket.emit(event, data);
@@ -33,6 +34,7 @@ export const DynamicSceneConnected: React.FC<DynamicSceneConnectedProps> = ({
     settings
   );
 
+  // ...and definitely this
   const emitRoomData = useRoomDataEmit(emit, roomContextData.roomData);
   const roomContextValue = {
     ...roomContextData,

--- a/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
+++ b/src/connection/DynamicScene/DynamicSceneConnected/index.tsx
@@ -6,7 +6,7 @@ import { EmitContext, EmitUpdate } from "../../EmitContext";
 import { RoomContext } from "../../RoomContext";
 import { useRoomContextData } from "./useRoomContextData";
 import { useRoomDataSyncing } from "./useRoomDataSyncing";
-import { useRoomDataEmit } from "./useRoomDataEmit";
+import { useEmitRoomData } from "./useEmitRoomData";
 
 export type DynamicSceneConnectedProps = {
   roomData: RoomData;
@@ -20,7 +20,8 @@ export const DynamicSceneConnected: React.FC<DynamicSceneConnectedProps> = ({
   settings,
   socket,
 }) => {
-  // ima document this lol
+  // This emit is a small, well-typed (via `EmitUpdate`) wrapper around `socket.emit`.
+  // It's passed to `EmitContext` consumers to let them send messages to the server.
   const emit = useCallback<EmitUpdate>(
     (event, data) => {
       socket.emit(event, data);
@@ -28,20 +29,25 @@ export const DynamicSceneConnected: React.FC<DynamicSceneConnectedProps> = ({
     [socket]
   );
 
+  // We next set up context data for the room by initializing React state for it.
+  // This sets up those pieces of granular state as members of an object.
   const roomContextData = useRoomContextData(
     socket.id as PersonId,
     roomData,
     settings
   );
 
-  // ...and definitely this
-  const emitRoomData = useRoomDataEmit(emit, roomContextData.roomData);
+  // Linking the two together, we now can make a general `emitRoomData` helper function.
+  // It'll emit room data updates to the server *and* update our React state.
+  const emitRoomData = useEmitRoomData(emit, roomContextData.roomData);
   const roomContextValue = {
     ...roomContextData,
     emitRoomData,
     originalRoomData: roomData,
   };
 
+  // Finally, we use the socket to subscribe to any room data updates from the server.
+  // They'll be applied automatically for us to the room data stored as React state.
   useRoomDataSyncing(roomContextValue, socket);
 
   return (

--- a/src/connection/DynamicScene/DynamicSceneConnected/useEmitRoomData.ts
+++ b/src/connection/DynamicScene/DynamicSceneConnected/useEmitRoomData.ts
@@ -6,27 +6,35 @@ import { RoomData } from "@shared/types";
 import { EmitUpdate } from "../../EmitContext";
 import { GetterAndSetter } from "../../types";
 
-// ...docs!!
-export const useRoomDataEmit = (
+/**
+ * Creates a function that takes in any amount of `RoomData` and simultaneously
+ * updates both React (local) state *and* the server (via a Socket.IO message).
+ */
+export const useEmitRoomData = (
   emit: EmitUpdate,
   roomData: GetterAndSetter<RoomData>
 ) => {
   const emitRoomData = useCallback(
     (newDataRequest: Partial<RoomData>) => {
+      // Whenever new data is passed to this locally, we first grab the old data
+      // and get the new data values that aren't the same as their old versions.
       const oldData = roomData.get();
       const updatedValues = Object.entries(newDataRequest).filter(
         ([key, value]) => oldData[key as keyof RoomData] !== value
       );
+
+      // If no new data values are different ("updated"), we can skip sending an update.
       if (updatedValues.length === 0) {
         return;
       }
 
+      // Otherwise, we package those new data values into a new object...
       const newData = Object.fromEntries(updatedValues);
 
-      // explain this
+      // ...update our local React state with them (which gets messaged to `RoomContext` consumers)...
       roomData.set({ ...oldData, ...newData });
 
-      // and this
+      // ...and emit an equivalent data update to the server.
       emit(KaraokeEvent.RoomDataUpdated, newData);
     },
     [emit, roomData]

--- a/src/connection/DynamicScene/DynamicSceneConnected/useRoomContextData.ts
+++ b/src/connection/DynamicScene/DynamicSceneConnected/useRoomContextData.ts
@@ -11,6 +11,10 @@ const useGetterAndSetter = <Value>(value: Value) => {
   };
 };
 
+/**
+ * Given the initial starting "room data" for a room, creates React state for each piece.
+ * Each piece is stored as a .get() to update its value and a .set() to write a new one.
+ */
 export const useRoomContextData = (
   id: PersonId,
   roomData: RoomData,

--- a/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataEmit.ts
+++ b/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataEmit.ts
@@ -6,11 +6,12 @@ import { RoomData } from "@shared/types";
 import { EmitUpdate } from "../../EmitContext";
 import { GetterAndSetter } from "../../types";
 
+// ...docs!!
 export const useRoomDataEmit = (
   emit: EmitUpdate,
   roomData: GetterAndSetter<RoomData>
 ) => {
-  const roomDataEmit = useCallback(
+  const emitRoomData = useCallback(
     (newDataRequest: Partial<RoomData>) => {
       const oldData = roomData.get();
       const updatedValues = Object.entries(newDataRequest).filter(
@@ -22,11 +23,14 @@ export const useRoomDataEmit = (
 
       const newData = Object.fromEntries(updatedValues);
 
+      // explain this
       roomData.set({ ...oldData, ...newData });
+
+      // and this
       emit(KaraokeEvent.RoomDataUpdated, newData);
     },
     [emit, roomData]
   );
 
-  return roomDataEmit;
+  return emitRoomData;
 };

--- a/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataSyncing.ts
+++ b/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataSyncing.ts
@@ -12,6 +12,7 @@ export const useRoomDataSyncing = (
   const { client, occupants, roomData } = roomContext;
   const { username } = client.get();
 
+  // mention probably todo be moved to the step 2
   useEffect(() => {
     socket.emit(KaraokeEvent.UsernameSet, { username });
   }, [socket, username]);

--- a/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataSyncing.ts
+++ b/src/connection/DynamicScene/DynamicSceneConnected/useRoomDataSyncing.ts
@@ -12,17 +12,17 @@ export const useRoomDataSyncing = (
   const { client, occupants, roomData } = roomContext;
   const { username } = client.get();
 
-  // mention probably todo be moved to the step 2
+  // Todo (#16): this could probably move to step 2 of data conneciton.
   useEffect(() => {
     socket.emit(KaraokeEvent.UsernameSet, { username });
   }, [socket, username]);
 
+  // This sets up a listener for the OccupantsUpdated event.
+  // We update our local occupants list for the new list of people.
   useEffect(() => {
     const onOccupantsUpdated = (data: OccupantsUpdatedData) => {
       occupants.set(
-        new Map(
-          data.occupants.map((otherPerson) => [otherPerson.id, otherPerson])
-        )
+        new Map(data.occupants.map((person) => [person.id, person]))
       );
     };
 
@@ -33,6 +33,8 @@ export const useRoomDataSyncing = (
     };
   }, [occupants, socket]);
 
+  // This sets up a listener for the RoomDataUpdated event.
+  // We override keys on local room data for any new provided values.
   useEffect(() => {
     const onRoomDataUpdated = (data: RoomDataUpdatedData) => {
       roomData.set({

--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -11,6 +11,9 @@ export type RoomContextValueTypes = Readonly<{
    */
   occupants: ReadonlyMap<PersonId, RoomPerson>;
 
+  /**
+   * Current (most recently updated) snapshot of the server state.
+   */
   roomData: RoomData;
 
   roomName: string;
@@ -41,5 +44,13 @@ export type AsGettersAndSetters<Values> = {
 export type RoomContextData = AsGettersAndSetters<RoomContextValueTypes>;
 
 export type RoomContextValue = RoomContextData & {
+  /**
+   * Updates local room data and emits any changes to the server.
+   */
   emitRoomData: (newRoomData: Partial<RoomData>) => void;
+
+  /**
+   * Snapshot of the room data as it was when first joined.
+   */
+  originalRoomData: RoomData;
 };

--- a/src/connection/useRoomConnection.ts
+++ b/src/connection/useRoomConnection.ts
@@ -1,30 +1,43 @@
 import { useEffect, useState } from "react";
 
 import { sceneElement } from "@components/elements";
+import { socketPort } from "@shared/ports";
 
 const globalOnConnectHook = "KaraokeNiteListenToConnection";
 
+/**
+ * Initializes the Networked-Aframe (NAF) scene and captures its
+ * Socket.IO client connection in React state.
+ */
 export const useRoomConnection = (roomName: string) => {
   const [socket, setSocket] = useState<SocketIOClient.Socket>();
 
-  // todo document this / link back to .md
+  // This registers a global listener function for when NAF connects,
+  // storing the connection socket in React state.
   useEffect(() => {
+    // We'll call this when we no longer want to listen for the global connection.
+    // That happens after we capture the socket *or* this effect is disposed by React.
     const stopListening = () => {
       delete window[globalOnConnectHook];
     };
 
+    // Store a function on window under the const key to be called by NAF when ready.
+    // This will store NAF's socket in React state, then delete this global listener.
     window[globalOnConnectHook] = () => {
       setSocket(NAF.connection.adapter.socket);
       stopListening();
     };
 
+    // Per NAF's documentation (https://github.com/networked-aframe/networked-aframe),
+    // we set the scene element to be a "networked-scene" to initialize NAF.
+    // The `onConnect` setting tells it to call the global function under that name when ready.
     sceneElement.setAttribute("networked-scene", {
       adapter: "webrtc",
       audio: "true",
       debug: process.env.NODE_ENV === "development",
       onConnect: globalOnConnectHook,
       room: roomName,
-      serverURL: `:3001`,
+      serverURL: `:${socketPort}`,
     });
 
     return stopListening;

--- a/src/connection/useRoomConnection.ts
+++ b/src/connection/useRoomConnection.ts
@@ -7,15 +7,14 @@ const globalOnConnectHook = "KaraokeNiteListenToConnection";
 export const useRoomConnection = (roomName: string) => {
   const [socket, setSocket] = useState<SocketIOClient.Socket>();
 
+  // todo document this / link back to .md
   useEffect(() => {
     const stopListening = () => {
       delete window[globalOnConnectHook];
     };
 
     window[globalOnConnectHook] = () => {
-      const newSocket = NAF.connection.adapter.socket;
-
-      setSocket(newSocket);
+      setSocket(NAF.connection.adapter.socket);
       stopListening();
     };
 

--- a/src/pages/room/RoomBody/template.html
+++ b/src/pages/room/RoomBody/template.html
@@ -1,11 +1,5 @@
 <a-scene dynamic-room>
   <a-assets>
-    <img
-      id="keyboard-image"
-      src="https://cdn.glitch.com/b316bbdc-0b0c-4c6d-94fb-fffb37f510a9%2Fsk-basic.png?v=1590379712131"
-      crossorigin="anonymous"
-    />
-
     <!-- Buttons -->
 
     <img
@@ -203,9 +197,9 @@
 
   <!-- Camera and Cursor -->
 
-  <a-camera> </a-camera>
+  <a-camera></a-camera>
 
-  <!-- Sky and Snow -->
+  <!-- Sky -->
 
   <a-sky src="#sky" rotation="0 -90 0"></a-sky>
 
@@ -216,7 +210,7 @@
   >
   </a-entity>
 
-  <!-- Keyboard -->
+  <!-- Mouse -->
 
   <a-entity id="mouseCursor" cursor="rayOrigin: mouse"></a-entity>
 

--- a/src/pages/room/RoomEvents/useEmitOnClick.ts
+++ b/src/pages/room/RoomEvents/useEmitOnClick.ts
@@ -3,6 +3,12 @@ import { useEvent } from "react-use";
 import { useRoomContext } from "@connection/RoomContext";
 import { RoomData } from "@shared/types";
 
+/**
+ * Adds a "click" listener to an element that updates room data.
+ *
+ * @param element - DOM element to listen to clicks on.
+ * @param getNewData - Generates a new section of room data from old room on demand.
+ */
 export const useEmitOnClick = (
   element: HTMLElement,
   getNewData: (oldRoomData: RoomData) => Partial<RoomData>

--- a/src/pages/room/RoomEvents/useVideoControls/index.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/index.ts
@@ -1,9 +1,11 @@
+import { useInitialVideoSetup } from "./useInitialVideoSetup";
 import { useTimeSynchronization } from "./useTimeSynchronization";
 import { useNextPreviousControls } from "./useNextPreviousControls";
 import { usePlayPauseControl } from "./usePlayPauseControl";
 import { useVolumeControls } from "./useVolumeControls";
 
 export const useVideoControls = () => {
+  useInitialVideoSetup();
   useTimeSynchronization();
   useNextPreviousControls();
   usePlayPauseControl();

--- a/src/pages/room/RoomEvents/useVideoControls/useInitialVideoSetup.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useInitialVideoSetup.ts
@@ -10,8 +10,8 @@ import { useRoomContext } from "@connection/RoomContext";
 export const useInitialVideoSetup = () => {
   const { originalRoomData } = useRoomContext();
 
-  // Called when the room is first initialized
-  // Todo move to its own hook
+  // Called when the room is first initialized to set the initial currentTime and
+  // play/pause status on the <video> element per the initial room data.
   useEffect(() => {
     // Video timing is, on average, behind by half of the sync interval.
     // currentTime is also measured in seconds instead of milliseconds for some reason.

--- a/src/pages/room/RoomEvents/useVideoControls/useInitialVideoSetup.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useInitialVideoSetup.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+import { videoElement } from "@components/elements";
+import { videoSyncInterval } from "@components/constants";
+import { useRoomContext } from "@connection/RoomContext";
+
+/**
+ * Initializes the video for when the room is first created.
+ */
+export const useInitialVideoSetup = () => {
+  const { originalRoomData } = useRoomContext();
+
+  // Called when the room is first initialized
+  // Todo move to its own hook
+  useEffect(() => {
+    // Video timing is, on average, behind by half of the sync interval.
+    // currentTime is also measured in seconds instead of milliseconds for some reason.
+    videoElement.currentTime =
+      originalRoomData.currentTime + videoSyncInterval / 2000;
+
+    if (originalRoomData.playing) {
+      videoElement.play();
+    }
+  }, [originalRoomData]);
+};

--- a/src/pages/room/RoomEvents/useVideoControls/useNextPreviousControls.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useNextPreviousControls.ts
@@ -6,18 +6,25 @@ import { allSongs } from "@shared/songs";
 
 import { useEmitOnClick } from "../useEmitOnClick";
 
+/**
+ * Hooks up the next and previous buttons to song index and the video element.
+ */
 export const useNextPreviousControls = () => {
   const { roomData } = useRoomContext();
   const { playing, songIndex, songs } = roomData.get();
 
+  // When the next button is clicked, move to the next song.
   useEmitOnClick(controls.nextButton, (oldRoomData) => ({
     songIndex: (oldRoomData.songIndex + 1) % songs.length,
   }));
 
+  // When the next button is clicked, move to the previous song.
   useEmitOnClick(controls.previousButton, (oldRoomData) => ({
     songIndex: Math.max(oldRoomData.songIndex - 1, 0),
   }));
 
+  // This effect is a reaction to song index change -sourced locally or from the server-.
+  // If the video needs a new src, set it, and play the video if it should be.
   useEffect(() => {
     const newSrc = allSongs[songs[songIndex]].audio;
     if (videoElement.getAttribute("src") === newSrc) {

--- a/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
@@ -4,10 +4,11 @@ import { controls, videoElement } from "@components/elements";
 import { useRoomContext } from "@connection/RoomContext";
 
 import { useEmitOnClick } from "../useEmitOnClick";
+import { videoSyncInterval } from "@components/constants";
 
 export const usePlayPauseControl = () => {
   const { originalRoomData, roomData } = useRoomContext();
-  const { currentTime, playing } = roomData.get();
+  const { playing } = roomData.get();
 
   useEmitOnClick(controls.playPauseButton, (oldRoomData) => ({
     currentTime: videoElement.currentTime,
@@ -22,10 +23,13 @@ export const usePlayPauseControl = () => {
     } else {
       videoElement.pause();
     }
-  }, [currentTime, playing]);
+  }, [playing]);
 
   useEffect(() => {
-    videoElement.currentTime = originalRoomData.currentTime;
+    // Video timing is, on average, behind by half of the sync interval.
+    // currentTime is also measured in seconds instead of milliseconds for some reason.
+    videoElement.currentTime =
+      originalRoomData.currentTime + videoSyncInterval / 2000;
 
     if (originalRoomData.playing) {
       videoElement.play();

--- a/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
@@ -10,11 +10,14 @@ export const usePlayPauseControl = () => {
   const { originalRoomData, roomData } = useRoomContext();
   const { playing } = roomData.get();
 
+  // ...
   useEmitOnClick(controls.playPauseButton, (oldRoomData) => ({
     currentTime: videoElement.currentTime,
     playing: !oldRoomData.playing,
   }));
 
+  // ...
+  // TODO document these bigger groups of things all over da place
   useEffect(() => {
     controls.playPauseButton.setAttribute("src", playing ? "#pause" : "#play");
 
@@ -25,6 +28,7 @@ export const usePlayPauseControl = () => {
     }
   }, [playing]);
 
+  // Called when the room is first initialized
   useEffect(() => {
     // Video timing is, on average, behind by half of the sync interval.
     // currentTime is also measured in seconds instead of milliseconds for some reason.

--- a/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
@@ -6,7 +6,7 @@ import { useRoomContext } from "@connection/RoomContext";
 import { useEmitOnClick } from "../useEmitOnClick";
 
 export const usePlayPauseControl = () => {
-  const { roomData } = useRoomContext();
+  const { originalRoomData, roomData } = useRoomContext();
   const { currentTime, playing } = roomData.get();
 
   useEmitOnClick(controls.playPauseButton, (oldRoomData) => ({
@@ -18,10 +18,17 @@ export const usePlayPauseControl = () => {
     controls.playPauseButton.setAttribute("src", playing ? "#pause" : "#play");
 
     if (playing) {
-      videoElement.currentTime = currentTime;
       videoElement.play();
     } else {
       videoElement.pause();
     }
   }, [currentTime, playing]);
+
+  useEffect(() => {
+    videoElement.currentTime = originalRoomData.currentTime;
+
+    if (originalRoomData.playing) {
+      videoElement.play();
+    }
+  }, [originalRoomData]);
 };

--- a/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/usePlayPauseControl.ts
@@ -29,6 +29,7 @@ export const usePlayPauseControl = () => {
   }, [playing]);
 
   // Called when the room is first initialized
+  // Todo move to its own hook
   useEffect(() => {
     // Video timing is, on average, behind by half of the sync interval.
     // currentTime is also measured in seconds instead of milliseconds for some reason.

--- a/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
@@ -5,12 +5,16 @@ import { videoElement } from "@components/elements";
 import { videoSyncInterval } from "@components/constants";
 import { useRoomContext } from "@connection/RoomContext";
 
+/**
+ * Synchronizes our view on the three places of video currentTime.
+ */
 export const useTimeSynchronization = () => {
   const { emitRoomData, roomData } = useRoomContext();
   const { currentTime, playing } = roomData.get();
 
-  // Constantly update the server on the current time of the video if playing
-  // Sending data from _DOM_ to _React_ and _Node_
+  // While we're playing, periodically update the server on the current vdeo time.
+  // This is sending data from **DOM** to **React** and **Node**.
+  // Todo (#14): only the player should do this.
   useInterval(() => {
     if (playing) {
       emitRoomData({
@@ -19,12 +23,11 @@ export const useTimeSynchronization = () => {
     }
   }, videoSyncInterval);
 
-  // If the video is paused, we can safely match its time to currentTime
-  // Sending data from _React_ to _DOM_
+  // While we're paused, we can constantly safely match its time to currentTime.
+  // This is sending data from **React** to the **DOM**.
   useEffect(() => {
     if (!playing) {
-      // todo: make a shared thingy for this? idk
-      videoElement.currentTime = currentTime + videoSyncInterval / 2000;
+      videoElement.currentTime = currentTime;
     }
   }, [currentTime, playing]);
 };

--- a/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useInterval } from "react-use";
 
 import { videoElement } from "@components/elements";
-import { useRoomContext } from "@connection/RoomContext";
 import { videoSyncInterval } from "@components/constants";
+import { useRoomContext } from "@connection/RoomContext";
 
 export const useTimeSynchronization = () => {
   const { emitRoomData, roomData } = useRoomContext();

--- a/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
@@ -10,6 +10,7 @@ export const useTimeSynchronization = () => {
   const { currentTime, playing } = roomData.get();
 
   // Constantly update the server on the current time of the video if playing
+  // Sending data from _DOM_ to _React_ and _Node_
   useInterval(() => {
     if (playing) {
       emitRoomData({
@@ -19,9 +20,11 @@ export const useTimeSynchronization = () => {
   }, videoSyncInterval);
 
   // If the video is paused, we can safely match its time to currentTime
+  // Sending data from _React_ to _DOM_
   useEffect(() => {
     if (!playing) {
-      videoElement.currentTime = currentTime;
+      // todo: make a shared thingy for this? idk
+      videoElement.currentTime = currentTime + videoSyncInterval / 2000;
     }
   }, [currentTime, playing]);
 };

--- a/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
@@ -3,22 +3,20 @@ import { useInterval } from "react-use";
 
 import { videoElement } from "@components/elements";
 import { useRoomContext } from "@connection/RoomContext";
-
-/**
- * How often to emit currentTime updates.
- */
-const videoElementSyncInterval = 1000;
+import { videoSyncInterval } from "@components/constants";
 
 export const useTimeSynchronization = () => {
   const { emitRoomData, roomData } = useRoomContext();
   const { currentTime, playing } = roomData.get();
 
-  // Constantly update the server on the current time of the video
+  // Constantly update the server on the current time of the video if playing
   useInterval(() => {
-    emitRoomData({
-      currentTime: videoElement.currentTime,
-    });
-  }, videoElementSyncInterval);
+    if (playing) {
+      emitRoomData({
+        currentTime: videoElement.currentTime,
+      });
+    }
+  }, videoSyncInterval);
 
   // If the video is paused, we can safely match its time to currentTime
   useEffect(() => {

--- a/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useTimeSynchronization.ts
@@ -13,12 +13,14 @@ export const useTimeSynchronization = () => {
   const { emitRoomData, roomData } = useRoomContext();
   const { currentTime, playing } = roomData.get();
 
+  // Constantly update the server on the current time of the video
   useInterval(() => {
     emitRoomData({
       currentTime: videoElement.currentTime,
     });
   }, videoElementSyncInterval);
 
+  // If the video is paused, we can safely match its time to currentTime
   useEffect(() => {
     if (!playing) {
       videoElement.currentTime = currentTime;

--- a/src/pages/room/RoomEvents/useVideoControls/useVolumeControls.ts
+++ b/src/pages/room/RoomEvents/useVideoControls/useVolumeControls.ts
@@ -1,24 +1,31 @@
 import { useEffect } from "react";
 
+import { volumeChangeRate } from "@components/constants";
 import { videoElement, controls } from "@components/elements";
 import { useRoomContext } from "@connection/RoomContext";
 
 import { useEmitOnClick } from "../useEmitOnClick";
 
+/**
+ * Hooks up events for the volume buttons.
+ */
 export const useVolumeControls = () => {
   const { roomData } = useRoomContext();
   const { volume } = roomData.get();
 
+  // When the volume up button is pressed, increase volume to at most 1.
   useEmitOnClick(controls.volumeHighButton, (oldRoomData) => ({
-    volume: Math.min(oldRoomData.volume + 0.25, 1),
+    volume: Math.min(oldRoomData.volume + volumeChangeRate, 1),
   }));
 
+  // When the volume up button is pressed, decrease volume to at least to 0.
   useEmitOnClick(controls.volumeLowButton, (oldRoomData) => ({
-    volume: Math.max(oldRoomData.volume - 0.25, 0),
+    volume: Math.max(oldRoomData.volume - volumeChangeRate, 0),
   }));
 
+  // Whenever the volume data changes -sourced locally or from the server-,
+  // we brighten or dim the buttons, and set the volume on the <video> element.
   useEffect(() => {
-    videoElement.volume = volume;
     controls.volumeHighButton.setAttribute(
       "opacity",
       volume === 1 ? "0.5" : "1"
@@ -27,5 +34,6 @@ export const useVolumeControls = () => {
       "opacity",
       volume === 0 ? "0.5" : "1"
     );
+    videoElement.volume = volume;
   }, [volume]);
 };

--- a/src/server/events/karaoke.ts
+++ b/src/server/events/karaoke.ts
@@ -42,6 +42,7 @@ export const karaokeEvents = ({
       // Ignore currentTime updates from any client who didn't click the play button.
       // This is a somewhat arbitrary measure to stop "currentTime battles", wherein
       // two clients go back and forth sending vastly different times to each other.
+      // todo: don't include this currentTime member on newData; we don't want to redundantly broadcast it
       currentTime:
         newPlayer === person.id
           ? data.currentTime ?? room.data.currentTime

--- a/src/server/events/karaoke.ts
+++ b/src/server/events/karaoke.ts
@@ -56,4 +56,6 @@ export const karaokeEvents = ({
     room.data = newData;
     io.in(room.name).emit(KaraokeEvent.RoomDataUpdated, newData);
   });
+
+  // todo: when a player leaves, they should no longer be the player on the server
 };

--- a/src/server/events/karaoke.ts
+++ b/src/server/events/karaoke.ts
@@ -42,7 +42,7 @@ export const karaokeEvents = ({
       // Ignore currentTime updates from any client who didn't click the play button.
       // This is a somewhat arbitrary measure to stop "currentTime battles", wherein
       // two clients go back and forth sending vastly different times to each other.
-      // todo: don't include this currentTime member on newData; we don't want to redundantly broadcast it
+      // See /docs/Video Synchronization.md.
       currentTime:
         newPlayer === person.id
           ? data.currentTime ?? room.data.currentTime
@@ -57,6 +57,4 @@ export const karaokeEvents = ({
     room.data = newData;
     io.in(room.name).emit(KaraokeEvent.RoomDataUpdated, newData);
   });
-
-  // todo: when a player leaves, they should no longer be the player on the server
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -39,6 +39,11 @@ export type RoomData = {
   environment: string;
 
   /**
+   * Client ID of the last person to trigger the play button.
+   */
+  player?: PersonId;
+
+  /**
    * Whether the current song is playing.
    */
   playing: boolean;


### PR DESCRIPTION
I'd jotted down some small fixes when we group discussed #9 that didn't get pushed or fully fleshed out before merge. Most of this PR is adding comments explaining existing areas of code. There are two actual code changes:

* Moved the code to set the video's `currentTime` and call `play()` if the room is playing to a new `useInitialVideoSetup()`, to make it more clear how it's different from `usePlayPauseControls()`/`useTimeSynchronization()`.
* Added the concept of a room `player` as the most recent person to click Play on a paused video. The server will only listen to `currentTime` updates from the `player`.
* Don't set video `currentTime` locally if the video is already playing.
    * This should fix the issue of videos being jittery during playback, since they were getting their time manually set inaccurately every few hundred milliseconds.